### PR TITLE
Telegram - File reference fix

### DIFF
--- a/media_downloader.py
+++ b/media_downloader.py
@@ -32,9 +32,9 @@ def _get_media_meta(
     Returns
     -------
     tuple
-        file_id, file_name
+        file_ref, file_name
     """
-    file_id: str = media_obj.file_id
+    file_ref: str = media_obj.file_ref
     if _type == "voice":
         file_format: str = media_obj.mime_type.split("/")[-1]
         file_name: str = os.path.join(
@@ -48,7 +48,7 @@ def _get_media_meta(
         file_name = os.path.join(THIS_DIR, _type, "")
     else:
         file_name = os.path.join(THIS_DIR, _type, media_obj.file_name)
-    return file_id, file_name
+    return file_ref, file_name
 
 
 def download_media(
@@ -80,24 +80,24 @@ def download_media(
     Returns
     -------
     integer
-        file_id, file_name
+        last_message_id
     """
     messages = client.iter_history(
         chat_id, offset_id=last_read_message_id, reverse=True
     )
-    last_id: int = 0
+    last_message_id: int = 0
     for message in messages:
         if message.media:
             for _type in media_types:
                 _media = getattr(message, _type, None)
                 if _media:
-                    file_id, file_name = _get_media_meta(_media, _type)
+                    file_ref, file_name = _get_media_meta(_media, _type)
                     download_path = client.download_media(
-                        file_id, file_name=file_name
+                        message, file_ref=file_ref, file_name=file_name
                     )
                     logger.info("Media downloaded - %s", download_path)
-        last_id = message.message_id
-    return last_id
+        last_message_id = message.message_id
+    return last_message_id
 
 
 def update_config(config: dict):

--- a/tests/test_media_downloader.py
+++ b/tests/test_media_downloader.py
@@ -37,32 +37,32 @@ class MockMessage:
 
 class MockAudio:
     def __init__(self, **kwargs):
-        self.file_id = kwargs["file_id"]
+        self.file_ref = kwargs["file_ref"]
         self.file_name = kwargs["file_name"]
 
 
 class MockDocument:
     def __init__(self, **kwargs):
-        self.file_id = kwargs["file_id"]
+        self.file_ref = kwargs["file_ref"]
         self.file_name = kwargs["file_name"]
 
 
 class MockPhoto:
     def __init__(self, **kwargs):
-        self.file_id = kwargs["file_id"]
+        self.file_ref = kwargs["file_ref"]
         self.date = kwargs["date"]
 
 
 class MockVoice:
     def __init__(self, **kwargs):
-        self.file_id = kwargs["file_id"]
+        self.file_ref = kwargs["file_ref"]
         self.mime_type = kwargs["mime_type"]
         self.date = kwargs["date"]
 
 
 class MockVideo:
     def __init__(self, **kwargs):
-        self.file_id = kwargs["file_id"]
+        self.file_ref = kwargs["file_ref"]
         self.file_name = kwargs["file_name"]
 
 
@@ -76,7 +76,7 @@ class MockClient:
                 id=1213,
                 media=True,
                 voice=MockVoice(
-                    file_id="AwADBQADbwAD2oTRVeHe5eXRFftfAg",
+                    file_ref="AwADBQADbwAD2oTRVeHe5eXRFftfAg",
                     mime_type="audio/ogg",
                     date=1564066430,
                 ),
@@ -99,7 +99,7 @@ class MediaDownloaderTestCase(unittest.TestCase):
             id=1,
             media=True,
             voice=MockVoice(
-                file_id="AwADBQADbwAD2oTRVeHe5eXRFftfAg",
+                file_ref="AwADBQADbwAD2oTRVeHe5eXRFftfAg",
                 mime_type="audio/ogg",
                 date=1564066430,
             ),
@@ -118,7 +118,7 @@ class MediaDownloaderTestCase(unittest.TestCase):
             id=2,
             media=True,
             photo=MockPhoto(
-                file_id="AgADBQAD5KkxG_FPQValJzQsJPyzhHcC", date=1565015712
+                file_ref="AgADBQAD5KkxG_FPQValJzQsJPyzhHcC", date=1565015712
             ),
         )
         result = _get_media_meta(message.photo, "photo")
@@ -132,7 +132,7 @@ class MediaDownloaderTestCase(unittest.TestCase):
             id=3,
             media=True,
             document=MockDocument(
-                file_id="AQADAgADq7LfMgAEIdy5DwAE4w4AAwI",
+                file_ref="AQADAgADq7LfMgAEIdy5DwAE4w4AAwI",
                 file_name="sample_document.pdf",
             ),
         )
@@ -150,7 +150,7 @@ class MediaDownloaderTestCase(unittest.TestCase):
             id=4,
             media=True,
             audio=MockAudio(
-                file_id="AQADAgADq7LfMgAEIdy5DwAE5Q4AAgEC",
+                file_ref="AQADAgADq7LfMgAEIdy5DwAE5Q4AAgEC",
                 file_name="sample_audio.mp3",
             ),
         )
@@ -168,7 +168,7 @@ class MediaDownloaderTestCase(unittest.TestCase):
             id=5,
             media=True,
             video=MockVideo(
-                file_id="CQADBQADeQIAAlL60FUCNMBdK8OjlAI",
+                file_ref="CQADBQADeQIAAlL60FUCNMBdK8OjlAI",
                 file_name="sample_video.mp4",
             ),
         )


### PR DESCRIPTION
As telegram made changes to its API backend, 
which requires pyrogram `download_media` method to pass the message object and optionally the file_ref value of the media object as parameters.

The above is discussed  in the following issue of pyrogram - https://github.com/pyrogram/pyrogram/issues/315

**FIX:**
- `Message object` along with `file_ref`to download_media method [here](https://github.com/Dineshkarthik/telegram_media_downloader/blob/09198411dde053abf852662638ce86b81a1f55e2/media_downloader.py#L96)