### PR TITLE
Add feature_request label to exemptLabels list of stale-bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,6 +5,7 @@ daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
   - enhancement
+  - feature_request
   - help wanted
   - good first issue
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
fixes: #36 

- add `feature_request` label used by the issue-label-bot to the list of `exemptLabels` used by stable-bot.