### PR TITLE
pip install to user path in GH-actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Get setuptools
+    - name: Get setuptools Unix
+      if: ${{ matrix.os != 'windows-latest' }}
+      run: pip install --upgrade pip setuptools codecov
+    - name: Get setuptools Windows
+      if: ${{ matrix.os == 'windows-latest' }}
       run: pip install --upgrade --user pip setuptools codecov
     - name: Install dependencies
       run: make deps

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Get setuptools
-      run: pip install --upgrade pip setuptools codecov
+      run: pip install --upgrade --user pip setuptools codecov
     - name: Install dependencies
       run: make deps
     - name: Code Check - Pylint


### PR DESCRIPTION
In unit-test GitHub actions pip install to the current user path.

fixes: #38 