### PR TITLE
Handle download failure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,39 +119,39 @@ A Python docstring is a string used to document a Python module, class, function
 The next example gives an idea of what a docstring looks like:
 ```py
 def add(num1: int, num2: int) -> int:
-    """
-    Add up two integer numbers.
+   """
+   Add up two integer numbers.
 
-    This function simply wraps the ``+`` operator, and does not
-    do anything interesting, except for illustrating what
-    the docstring of a very simple function looks like.
+   This function simply wraps the ``+`` operator, and does not
+   do anything interesting, except for illustrating what
+   the docstring of a very simple function looks like.
 
-    Parameters
-    ----------
-    num1 : int
-	    First number to add.
-    num2 : int
-	    Second number to add.
+   Parameters
+   ----------
+   num1: int
+      First number to add.
+   num2: int
+      Second number to add.
 
-    Returns
-    -------
-    int
-	    The sum of ``num1`` and ``num2``.
+   Returns
+   -------
+   int
+      The sum of ``num1`` and ``num2``.
 
-    See Also
-    --------
-    subtract : Subtract one integer from another.
+   See Also
+   --------
+   subtract : Subtract one integer from another.
 
-    Examples
-    --------
-    >>> add(2, 2)
-    4
-    >>> add(25, 0)
-    25
-    >>> add(10, -10)
-    0
-    """
-    return num1 + num2
+   Examples
+   --------
+   >>> add(2, 2)
+   4
+   >>> add(25, 0)
+   25
+   >>> add(10, -10)
+   0
+   """
+   return num1 + num2
 ```
 Some standards regarding docstrings exist, which make them easier to read, and allow them be easily exported to other formats such as html or pdf.
 
@@ -169,16 +169,16 @@ telegram-media-downloader uses a convention for commit message prefixes and layo
 
 Must be one of the following:
 -  **add**: Adding a new file
--   **ci**: Changes to CI configuration files and scripts (example: files inside `.github` folder)
--   **clean**: Code cleanup
--   **docs**: Additions/updates to documentation
--   **enh**: Enhancement, new functionality
--   **fix**: Bug fix
--   **perf**: A code change that improves performance
--   **refactor**: A code change that neither fixes a bug nor adds a feature
--   **style**: Changes that do not affect the meaning of the code (white-space, formatting, etc)
--   **test**: Additions/updates to tests
--   **type**: Type annotations
+-  **ci**: Changes to CI configuration files and scripts (example: files inside `.github` folder)
+-  **clean**: Code cleanup
+-  **docs**: Additions/updates to documentation
+-  **enh**: Enhancement, new functionality
+-  **fix**: Bug fix
+-  **perf**: A code change that improves performance
+-  **refactor**: A code change that neither fixes a bug nor adds a feature
+-  **style**: Changes that do not affect the meaning of the code (white-space, formatting, etc)
+-  **test**: Additions/updates to tests
+-  **type**: Type annotations
     
 #### Subject:
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ api_hash: your_api_hash
 api_id: your_api_id
 chat_id: telegram_chat_id
 last_read_message_id: 0
+ids_to_retry: []
 media_types:
 - audio
 - document
@@ -77,6 +78,7 @@ file_formats:
 - api_id - The api_id you got from telegram apps
 - chat_id -  The id of the chat/channel you want to download media. Which you get from the above-mentioned steps.
 - last_read_message_id - If it is the first time you are going to read the channel let it be `0` or if you have already used this script to download media it will have some numbers which are auto-updated after the scripts successful execution. Don't change it.
+- ids_to_retry - `Leave it as it is.` This is used by the downloader script to keep track of all skipped downloads so that it can be downloaded during the next execution of the script.
 - media_types - Type of media to download, you can update which type of media you want to download it can be one or any of the available types.
 - file_formats - File types to download for supported media types which are `audio`, `document` and `video`. Default format is `all`, downloads all files.
 

--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,7 @@ api_hash: your_api_hash
 api_id: your_api_id
 chat_id: telegram_chat_id
 last_read_message_id: 0
+ids_to_retry: []
 media_types:
 - audio
 - photo

--- a/pylintrc
+++ b/pylintrc
@@ -486,7 +486,7 @@ max-attributes=8
 max-bool-expr=5
 
 # Maximum number of branch for function / method body.
-max-branches=12
+max-branches=13
 
 # Maximum number of locals for function / method body.
 max-locals=15

--- a/pylintrc
+++ b/pylintrc
@@ -80,6 +80,7 @@ disable=
     invalid-name,
     bad-continuation,
     import-error,
+    broad-except,
 
 
 # Enable the message, report, category or checker with the given id(s). You can


### PR DESCRIPTION
The following changes are made on top of the work by @Lqlsoftware in his PR #62:

- Handling the FILE_REFERENCE_EXPIRED exception by retrying and re-fetching the file_reference
- In case of TimeoutError in [pyrogram.session](https://github.com/pyrogram/pyrogram/blob/master/pyrogram/session/session.py#L431) retry after 5 seconds.
- On download failure, all the failed message-ids are added to the config.yaml to a list called `ids_to_retry`
- Added unit-test to increase code-coverage.

#### Todo:
use the `ids_to_retry` elements during the next run of the script to download the skipped files from the previous download.

fixes: #52 #43 