### PR TITLE
Update `ids_to_retry` for every batch of processed messages

### DIFF
--- a/media_downloader.py
+++ b/media_downloader.py
@@ -31,6 +31,7 @@ def update_config(config: dict):
     config: dict
         Configuraiton to be written into config file.
     """
+    config["ids_to_retry"] = list(set(config["ids_to_retry"] + FAILED_IDS))
     with open("config.yaml", "w") as yaml_file:
         yaml.dump(config, yaml_file, default_flow_style=False)
     logger.info("Updated last read message_id to config file")
@@ -345,14 +346,11 @@ def main():
     updated_config = asyncio.get_event_loop().run_until_complete(
         begin_import(config, pagination_limit=100)
     )
-    updated_config["ids_to_retry"] = list(
-        set(updated_config["ids_to_retry"] + FAILED_IDS)
-    )
     if FAILED_IDS:
         logger.info(
             "Downloading of %d files failed. "
-            "Failed message ids are to config file.\n"
-            "Functionality to download failed downloads will be added "
+            "Failed message ids are added to config file.\n"
+            "Functionality to re-download failed downloads will be added "
             "in the next version of `Telegram-media-downloader`",
             len(set(FAILED_IDS)),
         )

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,6 +1,6 @@
 """Init namespace"""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 __license__ = "MIT License"
 __copyright__ = (
     "Copyright (C) 2019 Dineshkarthik <https://github.com/Dineshkarthik>"


### PR DESCRIPTION
Update the `FAILED_IDS` list to `ids_to_retry` field in config yaml file for every batch of messages being processed.

Fixes: #73 