### PR TITLE
Fixes for Bugs introduced in V2.0.0

### DIFF
--- a/media_downloader.py
+++ b/media_downloader.py
@@ -2,7 +2,6 @@
 import asyncio
 import logging
 import os
-from datetime import datetime as dt
 from typing import List, Optional, Tuple, Union
 
 import pyrogram
@@ -123,7 +122,7 @@ async def _get_media_meta(
             _type,
             "{}_{}.{}".format(
                 _type,
-                dt.utcfromtimestamp(media_obj.date).isoformat(),  # type: ignore
+                media_obj.date.isoformat(),  # type: ignore
                 file_format,
             ),
         )
@@ -311,8 +310,7 @@ async def begin_import(config: dict, pagination_limit: int) -> dict:
     await client.start()
     last_read_message_id: int = config["last_read_message_id"]
     messages_iter = client.get_chat_history(
-        config["chat_id"],
-        offset_id=last_read_message_id,
+        config["chat_id"], offset_id=last_read_message_id, reverse=True
     )
     messages_list: list = []
     pagination_count: int = 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Pyrogram==2.0.33
+https://github.com/Dineshkarthik/pyrogram/archive/refs/heads/master.zip
 PyYAML==6.0
 rich==12.5.1
 TgCrypto==1.2.3

--- a/tests/test_media_downloader.py
+++ b/tests/test_media_downloader.py
@@ -1,14 +1,13 @@
 """Unittest module for media downloader."""
 import asyncio
 import copy
-import logging
 import os
 import platform
 import unittest
+from datetime import datetime
 
 import mock
 import pyrogram
-import pytest
 
 from media_downloader import (
     _can_download,
@@ -158,7 +157,7 @@ class MockClient:
                 media=True,
                 voice=MockVoice(
                     mime_type="audio/ogg",
-                    date=1564066430,
+                    date=datetime(2019, 7, 25, 14, 53, 50),
                 ),
             ),
             MockMessage(
@@ -239,7 +238,7 @@ class MediaDownloaderTestCase(unittest.TestCase):
             media=True,
             voice=MockVoice(
                 mime_type="audio/ogg",
-                date=1564066430,
+                date=datetime(2019, 7, 25, 14, 53, 50),
             ),
         )
         result = self.loop.run_until_complete(
@@ -260,7 +259,7 @@ class MediaDownloaderTestCase(unittest.TestCase):
         message = MockMessage(
             id=2,
             media=True,
-            photo=MockPhoto(date=1565015712),
+            photo=MockPhoto(date=datetime(2019, 8, 5, 14, 35, 12)),
         )
         result = self.loop.run_until_complete(
             async_get_media_meta(message.photo, "photo")
@@ -338,7 +337,7 @@ class MediaDownloaderTestCase(unittest.TestCase):
             media=True,
             video_note=MockVideoNote(
                 mime_type="video/mp4",
-                date=1564066430,
+                date=datetime(2019, 7, 25, 14, 53, 50),
             ),
         )
         result = self.loop.run_until_complete(
@@ -513,7 +512,7 @@ class MediaDownloaderTestCase(unittest.TestCase):
                         media=True,
                         voice=MockVoice(
                             mime_type="audio/ogg",
-                            date=1564066340,
+                            date=datetime(2019, 7, 25, 14, 53, 50),
                         ),
                     ),
                     MockMessage(
@@ -554,7 +553,7 @@ class MediaDownloaderTestCase(unittest.TestCase):
                         media=True,
                         voice=MockVoice(
                             mime_type="audio/ogg",
-                            date=1564066340,
+                            date=datetime(2019, 7, 25, 14, 53, 50),
                         ),
                     ),
                     MockMessage(

--- a/tests/utils/test_log.py
+++ b/tests/utils/test_log.py
@@ -20,11 +20,11 @@ class MockLog:
 
 class MetaTestCase(unittest.TestCase):
     def test_log_filter(self):
-        result = LogFilter().filter(MockLog(funcName="send"))
+        result = LogFilter().filter(MockLog(funcName="invoke"))
         self.assertEqual(result, False)
 
         result1 = LogFilter().filter(MockLog(funcName="get_file"))
-        self.assertEqual(result1, False)
+        self.assertEqual(result1, True)
 
         result2 = LogFilter().filter(MockLog(funcName="Synced"))
         self.assertEqual(result2, True)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,5 +1,5 @@
 """Init namespace"""
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 __license__ = "MIT License"
 __copyright__ = "Copyright (C) 2019 Dineshkarthik <https://github.com/Dineshkarthik>"

--- a/utils/log.py
+++ b/utils/log.py
@@ -11,6 +11,6 @@ class LogFilter(logging.Filter):
 
     # pylint: disable = W0221
     def filter(self, record):
-        if record.funcName in ("send", "get_file"):
+        if record.funcName in ("invoke"):
             return False
         return True


### PR DESCRIPTION
The following bugs are fixed:
- Unable to download new files. This is temporarily fixed by using own fork of Pyrogram with reverse option in get_chat_history #286 
- Repeated download failures of certain files, this is due to the change in date object type send in message starting Pyrogram v2.x - #266 
- Suppress repeated timeout and re-connect warning from Pyrogram

Fixes: #286 #266 #284 #282