### PR TITLE
Fix - missing proxy configuration

### DIFF
--- a/media_downloader.py
+++ b/media_downloader.py
@@ -306,6 +306,7 @@ async def begin_import(config: dict, pagination_limit: int) -> dict:
         "media_downloader",
         api_id=config["api_id"],
         api_hash=config["api_hash"],
+        proxy=config.get("proxy"),
     )
     await client.start()
     last_read_message_id: int = config["last_read_message_id"]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,5 +1,5 @@
 """Init namespace"""
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 __license__ = "MIT License"
 __copyright__ = "Copyright (C) 2019 Dineshkarthik <https://github.com/Dineshkarthik>"


### PR DESCRIPTION
The new proxy configuration is not passed to the Pyrogram Client while imitating thus the proxy is not applied.

fixes: #299 #300 