### PR TITLE
Monkey Patch for pyrogram.utils.get_peer_type

### DIFF
--- a/media_downloader.py
+++ b/media_downloader.py
@@ -9,6 +9,17 @@ import yaml
 from pyrogram.types import Audio, Document, Photo, Video, VideoNote, Voice
 from rich.logging import RichHandler
 
+from pyrogram import utils
+def get_peer_type_new(peer_id: int) -> str:
+    peer_id_str = str(peer_id)
+    if not peer_id_str.startswith("-"):
+        return "user"
+    elif peer_id_str.startswith("-100"):
+        return "channel"
+    else:
+        return "chat"
+utils.get_peer_type = get_peer_type_new
+
 from utils.file_management import get_next_name, manage_duplicate_file
 from utils.log import LogFilter
 from utils.meta import print_meta


### PR DESCRIPTION
pyrogram.utils.get_peer_type returns an incorrect peer type which makes some channels not working.

this monkey patch will make it work.

Thanks parean from Stackoverflow for this monkey patch.

https://stackoverflow.com/a/79024310/2534117