### PR TITLE
feat: implement downloading specific threads from channels (#542)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ chats:
   - chat_id: telegram_chat_id_1
     last_read_message_id: 0
     ids_to_retry: []
-    # Local chat options map exactly as the globals (media_types, file_formats, etc.)
+    threads: [123, 456] # Local chat options map exactly as the globals (media_types, file_formats, etc.)
   - chat_id: telegram_chat_id_2
     last_read_message_id: 0
 
@@ -193,6 +193,7 @@ download_directory: null  # Custom directory path for downloads (absolute or rel
 start_date: null  # Filter messages after this date (ISO format, e.g., '2023-01-01' or '2023-01-01T00:00:00')
 end_date: null    # Filter messages before this date (ISO format)
 max_messages: null  # Limit the number of media items to download (integer)
+threads: null     # Optional list of thread IDs to download from selectively (e.g., [11, 22])
 
 # Download Pacing / Rate Limiting (optional, can also be set per-chat)
 max_concurrent_downloads: 4   # Max files downloading at once per batch (1 = fully sequential)
@@ -214,6 +215,7 @@ download_delay: null          # Delay between files: fixed (2) or random range (
 | `start_date` | Optional: Filter messages to download only those sent after this date (ISO format). Leave `null` to disable. |
 | `end_date` | Optional: Filter messages to download only those sent before this date (ISO format). Leave `null` to disable. |
 | `max_messages` | Optional: Limit the number of media items to download (integer). Leave `null` for unlimited. |
+| `threads` | Optional: List of thread IDs to specifically download from for a specific chat. Leave `null` to disable and download the entire chat. |
 | `max_concurrent_downloads` | Optional: Maximum number of files downloading simultaneously per batch. Lower values reduce ban risk. `1` = fully sequential. Default: `4`. |
 | `download_delay` | Optional: Pause between starting each file download (seconds). Use a number for a fixed delay (`2`) or a list for a random range (`[1, 5]`). Leave `null` for no delay. |
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ A meta of last read/downloaded message is stored in the config file so that in s
 |Language | `Python 3.8 ` and above|
 |Download media types|  audio, document, photo, video, video_note, voice|
 
+## 🎉 Version 3.5.0 - Specific Thread Downloading
+
+### What's New:
+- **Targeted Chat Threads**: Download only the messages from a specific thread or topic in your channels by assigning thread IDs!
+- **Extended Web UI Control**: An "Advanced Overrides" section brings thread targeting natively to the visual interface.
+
 ## 🎉 Version 3.4.0 - Interactive Web UI
 
 ### What's New:

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -11,6 +11,7 @@ chats:
     last_read_message_id: 0
     ids_to_retry: []
     # (Optional) You can override global settings per-chat:
+    # threads: [] # List of thread IDs to download (e.g. [1234, 5678])
     # download_directory: /custom/path/for/this/chat
     # media_types:
     # - photo

--- a/media_downloader.py
+++ b/media_downloader.py
@@ -580,15 +580,23 @@ async def process_chat(  # pylint: disable=too-many-locals,too-many-branches,too
     else:
         download_directory = None
 
-    thread_ids = chat_conf.get("threads", [])
-    if not isinstance(thread_ids, list):
+    thread_ids_raw = chat_conf.get("threads", global_config.get("threads", []))
+    thread_ids = []
+
+    if isinstance(thread_ids_raw, list):
+        for t in thread_ids_raw:
+            try:
+                thread_ids.append(int(str(t).strip()))
+            except ValueError:
+                logger.warning("Invalid thread ID '%s' ignored.", t)
+    else:
         try:
-            thread_ids = [int(str(thread_ids).strip())]
+            thread_ids.append(int(str(thread_ids_raw).strip()))
         except ValueError:
             logger.warning(
-                "Invalid threads value in config: %r; defaulting to none.", thread_ids
+                "Invalid threads value in config: %r; defaulting to none.",
+                thread_ids_raw,
             )
-            thread_ids = []
 
     # If threads is specified, create a combined generator of messages
     # across all threads. Otherwise, just fetch the whole chat.

--- a/media_downloader.py
+++ b/media_downloader.py
@@ -580,9 +580,37 @@ async def process_chat(  # pylint: disable=too-many-locals,too-many-branches,too
     else:
         download_directory = None
 
-    messages_iter = client.iter_messages(
-        chat_id, min_id=last_read_message_id, reverse=True
-    )
+    thread_ids = chat_conf.get("threads", [])
+    if not isinstance(thread_ids, list):
+        try:
+            thread_ids = [int(str(thread_ids).strip())]
+        except ValueError:
+            logger.warning(
+                "Invalid threads value in config: %r; defaulting to none.", thread_ids
+            )
+            thread_ids = []
+
+    # If threads is specified, create a combined generator of messages
+    # across all threads. Otherwise, just fetch the whole chat.
+    async def get_messages_iter():
+        if thread_ids:
+            for thread_id in thread_ids:
+                logger.info(
+                    "Fetching messages for thread %s in chat %s...", thread_id, chat_id
+                )
+                async for msg in client.iter_messages(
+                    chat_id,
+                    min_id=last_read_message_id,
+                    reverse=True,
+                    reply_to=thread_id,
+                ):
+                    yield msg
+        else:
+            async for msg in client.iter_messages(
+                chat_id, min_id=last_read_message_id, reverse=True
+            ):
+                yield msg
+
     messages_list: list = []
     pagination_count: int = 0
     ids_to_retry = chat_conf.get("ids_to_retry", global_config.get("ids_to_retry", []))
@@ -596,7 +624,7 @@ async def process_chat(  # pylint: disable=too-many-locals,too-many-branches,too
             pagination_count += 1
             messages_list.append(message)
 
-    async for message in messages_iter:  # type: ignore
+    async for message in get_messages_iter():  # type: ignore
         if end_date and message.date > end_date:
             continue
         if start_date and message.date < start_date:

--- a/media_downloader.py
+++ b/media_downloader.py
@@ -59,6 +59,8 @@ def update_config(config: dict):
     chats_config = config.get("chats", [])
     if chats_config:
         for chat_conf in chats_config:
+            if not isinstance(chat_conf, dict):
+                continue
             chat_id = chat_conf.get("chat_id")
             if chat_id and chat_id in DOWNLOADED_IDS and chat_id in FAILED_IDS:
                 chat_conf["ids_to_retry"] = (
@@ -744,6 +746,14 @@ async def begin_import(  # pylint: disable=too-many-locals,too-many-branches,too
         chats_to_process = [config]
     else:
         chats_to_process = chats_config
+
+    valid_chats = []
+    for c in chats_to_process:
+        if isinstance(c, dict) and "chat_id" in c:
+            valid_chats.append(c)
+        else:
+            logger.warning("Skipping invalid chat configuration: %r", c)
+    chats_to_process = valid_chats
 
     parallel_chats = config.get("parallel_chats", False)
     config_write_lock = asyncio.Lock()

--- a/media_downloader.py
+++ b/media_downloader.py
@@ -11,6 +11,7 @@ from typing import List, Optional, Tuple, Union
 from rich.logging import RichHandler
 from telethon import TelegramClient
 from telethon.errors import FileReferenceExpiredError
+from telethon.errors.rpcerrorlist import MsgIdInvalidError
 from telethon.tl.types import (
     Document,
     Message,
@@ -616,6 +617,14 @@ async def process_chat(  # pylint: disable=too-many-locals,too-many-branches,too
                         reply_to=thread_id,
                     ):
                         yield msg
+                except MsgIdInvalidError:
+                    # If chat_id is a broadcast channel, reply_to will fail.
+                    # Or the thread ID is completely invalid.
+                    logger.error(
+                        "Failed to fetch messages for thread %s in chat %s: Invalid Thread ID! "
+                        "(If this is a channel, you must use the linked discussion group's chat_id instead!)",
+                        thread_id, chat_id
+                    )
                 except Exception as e:
                     logger.error(
                         "Failed to fetch messages for thread %s in chat %s: %s",

--- a/media_downloader.py
+++ b/media_downloader.py
@@ -790,9 +790,7 @@ def main():
 
     updated_config = config
     try:
-        updated_config = asyncio.get_event_loop().run_until_complete(
-            begin_import(config, pagination_limit=100)
-        )
+        updated_config = asyncio.run(begin_import(config, pagination_limit=100))
     except KeyboardInterrupt:
         logger.warning(
             "KeyboardInterrupt received. Gentle exit triggered! "

--- a/media_downloader.py
+++ b/media_downloader.py
@@ -605,6 +605,7 @@ async def process_chat(  # pylint: disable=too-many-locals,too-many-branches,too
     # across all threads. Otherwise, just fetch the whole chat.
     async def get_messages_iter():
         if thread_ids:
+            all_thread_messages = []
             for thread_id in thread_ids:
                 logger.info(
                     "Fetching messages for thread %s in chat %s...", thread_id, chat_id
@@ -616,14 +617,15 @@ async def process_chat(  # pylint: disable=too-many-locals,too-many-branches,too
                         reverse=True,
                         reply_to=thread_id,
                     ):
-                        yield msg
+                        all_thread_messages.append(msg)
                 except MsgIdInvalidError:
                     # If chat_id is a broadcast channel, reply_to will fail.
                     # Or the thread ID is completely invalid.
                     logger.error(
                         "Failed to fetch messages for thread %s in chat %s: Invalid Thread ID! "
                         "(If this is a channel, you must use the linked discussion group's chat_id instead!)",
-                        thread_id, chat_id
+                        thread_id,
+                        chat_id,
                     )
                 except Exception as e:
                     logger.error(
@@ -632,6 +634,11 @@ async def process_chat(  # pylint: disable=too-many-locals,too-many-branches,too
                         chat_id,
                         e,
                     )
+
+            # Yield strictly chronologically
+            all_thread_messages.sort(key=lambda m: m.id)
+            for msg in all_thread_messages:
+                yield msg
         else:
             async for msg in client.iter_messages(
                 chat_id, min_id=last_read_message_id, reverse=True
@@ -799,7 +806,9 @@ def main():
 
     updated_config = config
     try:
-        updated_config = asyncio.run(begin_import(config, pagination_limit=100))
+        updated_config = asyncio.get_event_loop().run_until_complete(
+            begin_import(config, pagination_limit=100)
+        )
     except KeyboardInterrupt:
         logger.warning(
             "KeyboardInterrupt received. Gentle exit triggered! "

--- a/media_downloader.py
+++ b/media_downloader.py
@@ -608,13 +608,21 @@ async def process_chat(  # pylint: disable=too-many-locals,too-many-branches,too
                 logger.info(
                     "Fetching messages for thread %s in chat %s...", thread_id, chat_id
                 )
-                async for msg in client.iter_messages(
-                    chat_id,
-                    min_id=last_read_message_id,
-                    reverse=True,
-                    reply_to=thread_id,
-                ):
-                    yield msg
+                try:
+                    async for msg in client.iter_messages(
+                        chat_id,
+                        min_id=last_read_message_id,
+                        reverse=True,
+                        reply_to=thread_id,
+                    ):
+                        yield msg
+                except Exception as e:
+                    logger.error(
+                        "Failed to fetch messages for thread %s in chat %s: %s",
+                        thread_id,
+                        chat_id,
+                        e,
+                    )
         else:
             async for msg in client.iter_messages(
                 chat_id, min_id=last_read_message_id, reverse=True

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -62,6 +62,8 @@ class TestThreadsDownloading(unittest.TestCase):
                 "media_downloader.FAILED_IDS", {}
             ), patch(
                 "media_downloader.db.record_download"
+            ), patch(
+                "media_downloader.update_config"
             ):
 
                 # The test will hang if we don't return 0 here at some point
@@ -104,6 +106,8 @@ class TestThreadsDownloading(unittest.TestCase):
                 "media_downloader.FAILED_IDS", {}
             ), patch(
                 "media_downloader.db.record_download"
+            ), patch(
+                "media_downloader.update_config"
             ):
 
                 process_messages_mock.return_value = 0  # Break loop immediately
@@ -136,6 +140,8 @@ class TestThreadsDownloading(unittest.TestCase):
                 "media_downloader.FAILED_IDS", {}
             ), patch(
                 "media_downloader.db.record_download"
+            ), patch(
+                "media_downloader.update_config"
             ):
 
                 process_messages_mock.return_value = 0  # Break loop immediately

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -43,7 +43,7 @@ class TestThreadsDownloading(unittest.TestCase):
         self.client = MockClientWithThreads()
 
     def test_process_chat_with_threads(self):
-        chat_conf = {"chat_id": 12345, "threads": [11, 22]}
+        chat_conf = {"chat_id": 12345, "threads": ["11", "22", "invalid_string"]}
         global_config = {}
         config_write_lock = asyncio.Lock()
 

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -32,7 +32,12 @@ class MockClientWithThreads:
 class TestThreadsDownloading(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.loop = asyncio.get_event_loop()
+        cls.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(cls.loop)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.loop.close()
 
     def setUp(self):
         self.client = MockClientWithThreads()

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -1,0 +1,148 @@
+import asyncio
+import unittest
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from media_downloader import process_chat
+
+
+class MockMessage:
+    def __init__(self, id, date):
+        self.id = id
+        self.date = date
+        self.media = None
+
+
+class MockClientWithThreads:
+    def __init__(self):
+        self.iter_messages_calls = []
+        self.get_messages_calls = []
+
+    async def get_messages(self, *args, **kwargs):
+        self.get_messages_calls.append(kwargs)
+        return []
+
+    async def iter_messages(self, *args, **kwargs):
+        self.iter_messages_calls.append(kwargs)
+        # Yield one dummy message so loop runs once
+        msg = MockMessage(1, datetime.now())
+        yield msg
+
+
+class TestThreadsDownloading(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.loop = asyncio.get_event_loop()
+
+    def setUp(self):
+        self.client = MockClientWithThreads()
+
+    def test_process_chat_with_threads(self):
+        chat_conf = {"chat_id": 12345, "threads": [11, 22]}
+        global_config = {}
+        config_write_lock = asyncio.Lock()
+
+        async def run_test():
+            with patch(
+                "media_downloader.process_messages", new_callable=AsyncMock
+            ) as process_messages_mock, patch(
+                "asyncio.sleep", new_callable=AsyncMock
+            ), patch(
+                "media_downloader.CURRENT_BATCH_IDS", {}
+            ), patch(
+                "media_downloader.PROCESSED_IDS", {}
+            ), patch(
+                "media_downloader.DOWNLOADED_IDS", {}
+            ), patch(
+                "media_downloader.FAILED_IDS", {}
+            ), patch(
+                "media_downloader.db.record_download"
+            ):
+
+                # The test will hang if we don't return 0 here at some point
+                process_messages_mock.side_effect = [
+                    1,
+                    2,
+                    0,
+                ]  # Returns 0 on 3rd call to break the loop
+
+                await process_chat(
+                    self.client, global_config, chat_conf, 100, config_write_lock
+                )
+
+            self.assertGreaterEqual(len(self.client.iter_messages_calls), 2)
+
+            # Verify call arguments
+            calls = [c.get("reply_to") for c in self.client.iter_messages_calls]
+            self.assertIn(11, calls)
+            self.assertIn(22, calls)
+
+        self.loop.run_until_complete(run_test())
+
+    def test_process_chat_without_threads(self):
+        chat_conf = {"chat_id": 12345, "threads": []}
+        global_config = {}
+        config_write_lock = asyncio.Lock()
+
+        async def run_test():
+            with patch(
+                "media_downloader.process_messages", new_callable=AsyncMock
+            ) as process_messages_mock, patch(
+                "asyncio.sleep", new_callable=AsyncMock
+            ), patch(
+                "media_downloader.CURRENT_BATCH_IDS", {}
+            ), patch(
+                "media_downloader.PROCESSED_IDS", {}
+            ), patch(
+                "media_downloader.DOWNLOADED_IDS", {}
+            ), patch(
+                "media_downloader.FAILED_IDS", {}
+            ), patch(
+                "media_downloader.db.record_download"
+            ):
+
+                process_messages_mock.return_value = 0  # Break loop immediately
+                await process_chat(
+                    self.client, global_config, chat_conf, 100, config_write_lock
+                )
+
+            self.assertGreaterEqual(len(self.client.iter_messages_calls), 1)
+            self.assertNotIn("reply_to", self.client.iter_messages_calls[0])
+
+        self.loop.run_until_complete(run_test())
+
+    def test_process_chat_with_single_thread(self):
+        chat_conf = {"chat_id": 12345, "threads": 33}
+        global_config = {}
+        config_write_lock = asyncio.Lock()
+
+        async def run_test():
+            with patch(
+                "media_downloader.process_messages", new_callable=AsyncMock
+            ) as process_messages_mock, patch(
+                "asyncio.sleep", new_callable=AsyncMock
+            ), patch(
+                "media_downloader.CURRENT_BATCH_IDS", {}
+            ), patch(
+                "media_downloader.PROCESSED_IDS", {}
+            ), patch(
+                "media_downloader.DOWNLOADED_IDS", {}
+            ), patch(
+                "media_downloader.FAILED_IDS", {}
+            ), patch(
+                "media_downloader.db.record_download"
+            ):
+
+                process_messages_mock.return_value = 0  # Break loop immediately
+                await process_chat(
+                    self.client, global_config, chat_conf, 100, config_write_lock
+                )
+
+            self.assertGreaterEqual(len(self.client.iter_messages_calls), 1)
+            self.assertEqual(self.client.iter_messages_calls[0].get("reply_to"), 33)
+
+        self.loop.run_until_complete(run_test())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,5 +1,5 @@
 """Init namespace"""
 
-__version__ = "3.4.0"
+__version__ = "3.5.0"
 __license__ = "MIT License"
 __copyright__ = "Copyright (C) 2019 Dineshkarthik <https://github.com/Dineshkarthik>"

--- a/webui/config_tab.py
+++ b/webui/config_tab.py
@@ -300,6 +300,22 @@ def build_config_tab(config: dict, save_config_fn):
                                         .classes("col")
                                         .props('outlined dense hint="e.g. 2 or 1,5"')
                                     )
+                                with ui.row().style(
+                                    "gap: 12px; width: 100%; margin-top: 4px;"
+                                ):
+                                    c_threads_val = chat_data.get("threads", [])
+                                    c_threads_str = (
+                                        ",".join(map(str, c_threads_val))
+                                        if isinstance(c_threads_val, list)
+                                        else str(c_threads_val)
+                                    )
+                                    c_inputs["threads"] = (
+                                        ui.input("Threads", value=c_threads_str)
+                                        .classes("col")
+                                        .props(
+                                            'outlined dense hint="Comma-separated thread IDs e.g. 1234, 5678"'
+                                        )
+                                    )
 
                             ui.separator().style("opacity: 0.5")
 
@@ -563,6 +579,16 @@ def build_config_tab(config: dict, save_config_fn):
                 chat_obj["end_date"] = c_in["end_date"].value.strip()
             if c_in["max_messages"].value is not None:
                 chat_obj["max_messages"] = int(c_in["max_messages"].value)
+
+            c_threads_str = (
+                c_in.get("threads").value.strip() if c_in.get("threads") else ""
+            )
+            if c_threads_str:
+                chat_obj["threads"] = [
+                    int(x.strip())
+                    for x in c_threads_str.split(",")
+                    if x.strip().isdigit()
+                ]
 
             # Chat-specific file_formats
             chat_formats = {}


### PR DESCRIPTION
### Description
This pull request implements the requested feature to download specific threads from Telegram channels as described in Issue #542.

### Changes
- **Configuration updated**: Added an optional `threads` array parameter directly into `config.yaml.example` under the chat configuration layout to explicitly state a list of thread IDs to process per chat.
- **Message Iterator Rewritten**: Created `get_messages_iter()` within `media_downloader.py` allowing iterating over Telegram messages and seamlessly looping the `telethon` client's existing `iter_messages` function utilizing `reply_to=thread_id` parameters natively if the user has opted to use the `threads` list configuration. Falls back completely to traditional behavior otherwise.
- **Web Interface Upgrade**: Incorporated a visual configuration text box enabling inserting threads conveniently via the advanced overrides option without interacting with complex file configuration for end users.
- **Tests Added**: Wrote test mock structures that simulate iterative `reply_to` fetching via `unittest` utilizing explicit event loops to provide assertions tracking how the logic behaves directly within the downloader script independently.